### PR TITLE
Drop support for perl 5.10, 5.12, add 5.22, 5.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: perl
 perl:
+    - "5.24"
+    - "5.22"
     - "5.20"
     - "5.18"
     - "5.16"
     - "5.14"
-    - "5.12"
-    - "5.10"
 before_install: cpanm --quiet --notest Devel::CheckLib

--- a/t/netldns.t
+++ b/t/netldns.t
@@ -80,7 +80,8 @@ SKIP: {
     is( scalar( $se->answer ),     0,  'zero answers' );
     is( scalar( $se->authority ), 10,  'nine authority' );
     my $add = scalar( $se->additional );
-    ok( $add == 16 || $add == 15, 'sixteen additional' );
+    cmp_ok( $add, '<=', 20, 'at most 20 additional' );
+    cmp_ok( $add, '>=', 8, 'at least 8 additional' );
 
     my $rr = Net::LDNS::RR->new_from_string(
         'se. 172800	IN	SOA	catcher-in-the-rye.nic.se. registry-default.nic.se. 2013111305 1800 1800 864000 7200' );

--- a/t/netldns.t
+++ b/t/netldns.t
@@ -35,7 +35,7 @@ SKIP: {
     ok( !$p2->ad(),    'AD bit not set' );
     ok( !$p2->do(),    'DO bit not set' );
 
-    ok( $p2->querytime > 0 );
+    cmp_ok( $p2->querytime, '>=', 0);
     is( $p2->answerfrom, '8.8.8.8', 'expected answerfrom' );
     $p2->answerfrom( '1.2.3.4' );
     is( $p2->answerfrom, '1.2.3.4', 'setting answerfrom works' );


### PR DESCRIPTION
We're updating the set of supported OS versions, and consequently we're adding and dropping support for Perl versions as well.

This PR also loosens the test suite's assumptions about the Internet in order to make it pass. The test suite uses the Internet as a source of test data. Every now and then the state of the Internet changes and the tests have to updated. A better solution would be to only use static test data, but that's out of scope for this release.