### PR TITLE
Updated to adjust for changes in live data

### DIFF
--- a/t/netldns.t
+++ b/t/netldns.t
@@ -78,7 +78,9 @@ SKIP: {
 
     is( scalar( $se->question ),   1,  'one question' );
     is( scalar( $se->answer ),     0,  'zero answers' );
-    is( scalar( $se->authority ), 10,  'nine authority' );
+    my $authority = scalar $se->authority;
+    cmp_ok( $authority, '<=', 13, 'at most 13 NS (authority)' );
+    cmp_ok( $authority, '>=', 6, 'at least 6 NS (authority)' );
     my $add = scalar( $se->additional );
     cmp_ok( $add, '<=', 20, 'at most 20 additional' );
     cmp_ok( $add, '>=', 8, 'at least 8 additional' );

--- a/t/netldns.t
+++ b/t/netldns.t
@@ -82,7 +82,7 @@ SKIP: {
     cmp_ok( $authority, '<=', 13, 'at most 13 NS (authority)' );
     cmp_ok( $authority, '>=', 6, 'at least 6 NS (authority)' );
     my $add = scalar( $se->additional );
-    cmp_ok( $add, '<=', 20, 'at most 20 additional' );
+    cmp_ok( $add, '<=', 26, 'at most 20 additional' );
     cmp_ok( $add, '>=', 8, 'at least 8 additional' );
 
     my $rr = Zonemaster::LDNS::RR->new_from_string(


### PR DESCRIPTION
Updated to adjust for changes in live data and replace fixed value of NS with range. Also updated accepted range of additional records to match range of NS.

This is a duplicate of PR #37 whose changes were reset because they were merged to wrong branch.