### PR TITLE
Allow loading ldns as an ordinary dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,15 +14,14 @@ all_from 'lib/Zonemaster/LDNS.pm';
 repository 'https://github.com/dotse/zonemaster-ldns';
 bugtracker 'https://github.com/dotse/zonemaster-ldns/issues';
 
-my $opt_randomize = 0;
-my $opt_idn       = 1;
+my $opt_randomize     = 0;
+my $opt_idn           = 1;
+my $opt_internal_ldns = 0;
 GetOptions(
-    'randomize!' => \$opt_randomize,
-    'idn!'       => \$opt_idn,
+    'randomize!'     => \$opt_randomize,
+    'idn!'           => \$opt_idn,
+    'internal-ldns!' => \$opt_internal_ldns,
 );
-
-cc_include_paths( 'include' );
-cc_include_paths( 'ldns' );
 
 configure_requires 'Devel::CheckLib';
 requires 'MIME::Base64';
@@ -31,8 +30,18 @@ test_requires 'Test::Fatal';
 
 use_ppport 3.19;
 cc_libs 'crypto';
+cc_include_paths 'include';
 cc_src_paths 'src';
-cc_libs( '-Lldns/lib' );
+
+if ( $opt_internal_ldns ) {
+    cc_libs '-Lldns/lib';
+    cc_include_paths 'ldns';
+    print "Feature internal ldns enabled\n";
+}
+else {
+    cc_libs 'ldns';
+    print "Feature internal ldns disabled\n";
+}
 
 my %assert_args = (
     lib      => 'crypto',
@@ -66,7 +75,8 @@ else {
 }
 
 sub MY::postamble {
-    return <<'TARGET';
+
+    my $internal_ldns_make = <<'END_INTERNAL_LDNS';
 
 LDFROM += ldns/.libs/libldns.a
 
@@ -82,6 +92,10 @@ ldns/configure:
 	cd ldns ; libtoolize -ci
 	cd ldns ; autoreconf -fi
 
+END_INTERNAL_LDNS
+
+    my $contributors_make = <<'END_CONTRIBUTORS';
+
 CONTRIBUTORS.txt:
 	@( \
 	echo "This module is based on the ldns library from NLnet Labs <https://www.nlnetlabs.nl/projects/ldns/>" ; \
@@ -90,7 +104,26 @@ CONTRIBUTORS.txt:
 	git shortlog -sne | cut -b8- \
 	) >| CONTRIBUTORS.txt
 
-TARGET
+END_CONTRIBUTORS
+
+    my $postamble = '';
+
+    $postamble .= $contributors_make;
+    $postamble .= $internal_ldns_make if !$opt_internal_ldns;
+
+    return $postamble;
+}
+
+sub MY::test_via_harness {
+    local $_ = shift()->MM::test_via_harness(@_);
+    s/\bPERL_DL_NONLAZY=1 +//g;
+    return $_;
+}
+
+sub MY::test_via_script {
+    local $_ = shift()->MM::test_via_script(@_);
+    s/\bPERL_DL_NON_LAZY=1 +//g;
+    return $_;
 }
 
 WriteAll;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ bugtracker 'https://github.com/dotse/zonemaster-ldns/issues';
 
 my $opt_randomize     = 0;
 my $opt_idn           = 1;
-my $opt_internal_ldns = 0;
+my $opt_internal_ldns = 1;
 GetOptions(
     'randomize!'     => \$opt_randomize,
     'idn!'           => \$opt_idn,
@@ -109,7 +109,7 @@ END_CONTRIBUTORS
     my $postamble = '';
 
     $postamble .= $contributors_make;
-    $postamble .= $internal_ldns_make if !$opt_internal_ldns;
+    $postamble .= $internal_ldns_make if $opt_internal_ldns;
 
     return $postamble;
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 Zonemaster LDNS
 ===============
 
+**Table of contents**
+
+* [Introduction](#introduction)
+* [Dependencies and Compatibility](#dependencies-and-compatibility)
+* [Installation and verification](#installation-and-verification)
+  * [Recommended installation](#recommended-installation)
+  * [Installation from source](#installation-from-source)
+  * [Post-installation sanity check](#post-installation-sanity-check)
+  * [Testing](#testing)
+* [Optional features](#optional-features)
+  * [IDN](#idn)
+  * [Internal ldns](#internal-ldns)
+  * [Randomized capitalization](#randomized-capitalization)
+
+
 ## Introduction
 
 This module provides a Perl interface to the [ldns library](https://www.nlnetlabs.nl/projects/ldns/) from [NLnet Labs](https://www.nlnetlabs.nl/). This module includes the necessary C code from ldns, so the library does not need to be globally installed. It does, however, rely on a sufficiently recent version of OpenSSL being present.
@@ -11,6 +26,66 @@ If you want a module that specifically aims to be a complete and transparent int
 
 Initially this module was named Net::LDNS.
 
+## Dependencies and compatibility
+
+Run-time dependencies:
+ * `openssl`
+ * `libidn` (if [IDN] is enabled)
+ * `libldns` (if [Internal ldns] is disabled)
+
+Compile-time dependencies (only when installing from source):
+ * `make`
+ * `Devel::CheckLib`
+ * `git` (if [Internal ldns] is enabled)
+ * `libtool` (if [Internal ldns] is enabled)
+ * `autoconf` (if [Internal ldns] is enabled)
+ * `automake` (if [Internal ldns] is enabled)
+
+Test-time dependencies:
+ * `Test::Fatal`
+
+There is a small part in the code that may not be compatible with non-Unix operating systems, in that it assumes that the file /dev/null exists.
+
+## Installation and verification
+
+### Recommended installation
+
+The recommended way to install Zonemaster::LDNS is to install it from CPAN as a dependency to Zonemaster::Engine. If you follow the [installation instructions for Zonemaster::Engine](https://github.com/dotse/zonemaster-engine/blob/master/docs/Installation.md) you will get all the prerequisites and dependencies for Zonemaster::LDNS before installing it from CPAN.
+
+### Installation from source
+
+Override the default set of features by appending `--FEATURE` and/or
+`--no-FEATURE` options to the `perl Makefile.PL` command.
+
+```sh
+git clone https://github.com/dotse/zonemaster-ldns
+cd zonemaster-ldns
+perl Makefile.PL
+make
+make test
+make install
+```
+
+> **Note:** The source ZIP files downloaded from Github are broken with
+> respect to this instruction.
+
+### Post-installation sanity check
+
+```sh
+perl -MZonemaster::LDNS -E 'say Zonemaster::LDNS->new("8.8.8.8")->query("zonemaster.net")->string'
+```
+
+The above command should print some `dig`-like output.
+
+### Testing
+
+Some of the unit tests depend on data on Internet, which may change. To avoid false 
+fails, those unit tests are only run if the environment variable `TEST_WITH_NETWORK` is `true`. By default that variable
+is unset (those tests are not run). To run all tests, execute
+
+```sh
+TEST_WITH_NETWORK=1 make test
+```
 
 ## Optional features
 
@@ -52,74 +127,6 @@ Enable with `--randomize`.
 > **Note:** This feature is experimental.
 
 Randomizes the capitalization of returned domain names.
-
-
-## Dependencies
-
-Run-time dependencies:
- * `openssl`
- * `libidn` (if [IDN] is enabled)
- * `libldns` (if [Internal ldns] is disabled)
-
-Compile-time dependencies (only when installing from source):
- * `make`
- * `Devel::CheckLib`
- * `git` (if [Internal ldns] is enabled)
- * `libtool` (if [Internal ldns] is enabled)
- * `autoconf` (if [Internal ldns] is enabled)
- * `automake` (if [Internal ldns] is enabled)
-
-Test-time dependencies:
- * `Test::Fatal`
-
-
-## Installation
-
-### Recommended installation
-
-The recommended way to install Zonemaster::LDNS is to install it from CPAN as a dependency to Zonemaster::Engine. If you follow the [installation instructions for Zonemaster::Engine](https://github.com/dotse/zonemaster-engine/blob/master/docs/Installation.md) you will get all the prerequisites for Zonemaster::LDNS before installing it from CPAN.
-
-### Installation from source
-
-Override the default set of features by appending `--FEATURE` and/or
-`--no-FEATURE` options to the `perl Makefile.PL` command.
-
-```sh
-git clone https://github.com/dotse/zonemaster-ldns
-cd zonemaster-ldns
-perl Makefile.PL
-make
-make test
-make install
-```
-
-> **Note:** The source ZIP files downloaded from Github are broken with
-> respect to this instruction.
-
-
-## Post-installation sanity check
-
-```sh
-perl -MZonemaster::LDNS -E 'say Zonemaster::LDNS->new("8.8.8.8")->query("zonemaster.net")->string'
-```
-
-The above command should print some `dig`-like output.
-
-
-## Testing
-
-Some of the unit tests depend on data on Internet, which may change. To avoid false 
-fails, those unit tests are only run if the environment variable `TEST_WITH_NETWORK` is `true`. By default that variable
-is unset (those tests are not run). To run all tests, execute
-
-```sh
-TEST_WITH_NETWORK=1 make test
-```
-
-
-## Compatibility
-
-There is a small part in the code that may not be compatible with non-Unix operating systems, in that it assumes that the file /dev/null exists.
 
 
 [IDN]: #idn

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want a module that specifically aims to be a complete and transparent int
 Initially this module was named Net::LDNS.
 
 
-## Features
+## Optional features
 
 When installing from source, you can choose to enable or disable a number
 of optional features using command line options to the `perl Makefile.PL`
@@ -35,6 +35,15 @@ although that should cover a lot of real-world use cases.
 > **Note:** The Zonemaster Engine test suite assumes this feature
 > is enabled.
 
+### Internal ldns
+
+Enabled by default.
+Disable with `--no-internal-ldns`.
+
+When enabled, an included version of ldns is statically linked into
+Zonemaster::LDNS.
+When disabled, libldns is dynamically linked just like other dependencies.
+
 ### Randomized capitalization
 
 Disabled by default.
@@ -47,23 +56,31 @@ Randomizes the capitalization of returned domain names.
 
 ## Dependencies
 
-This module depends on the `openssl` library and has an optional
-dependency on the `libidn` (with the [IDN](#idn) feature, enabled by
-default) library.
+Run-time dependencies:
+ * `openssl`
+ * `libidn` (if [IDN] is enabled)
+ * `libldns` (if [Internal ldns] is disabled)
+
+Compile-time dependencies (only when installing from source):
+ * `make`
+ * `Devel::CheckLib`
+ * `git` (if [Internal ldns] is enabled)
+ * `libtool` (if [Internal ldns] is enabled)
+ * `autoconf` (if [Internal ldns] is enabled)
+ * `automake` (if [Internal ldns] is enabled)
+
+Test-time dependencies:
+ * `Test::Fatal`
 
 
 ## Installation
 
+### Recommended installation
+
 The recommended way to install Zonemaster::LDNS is to install it from CPAN as a dependency to Zonemaster::Engine. If you follow the [installation instructions for Zonemaster::Engine](https://github.com/dotse/zonemaster-engine/blob/master/docs/Installation.md) you will get all the prerequisites for Zonemaster::LDNS before installing it from CPAN.
 
-To install Zonemaster LDNS from from sources, follow the instruction
-below.
+### Installation from source
 
-> **Note:** This procedure has additional compile-time dependencies on
-> `git`, `libtool`, `autoconf`, `automake`, `make` and `Devel::CheckLib`,
-> as well as a test-time dependency on `Test::Fatal`.
-
-Install this module with the following commands.
 Override the default set of features by appending `--FEATURE` and/or
 `--no-FEATURE` options to the `perl Makefile.PL` command.
 
@@ -103,3 +120,7 @@ TEST_WITH_NETWORK=1 make test
 ## Compatibility
 
 There is a small part in the code that may not be compatible with non-Unix operating systems, in that it assumes that the file /dev/null exists.
+
+
+[IDN]: #idn
+[Internal ldns]: #internal-ldns


### PR DESCRIPTION
Fixes #48 by introducing the --no-internal-ldns feature switch.